### PR TITLE
Included failsafe and edited break condition

### DIFF
--- a/src/amuse/ext/masc/cluster.py
+++ b/src/amuse/ext/masc/cluster.py
@@ -113,6 +113,7 @@ def new_masses(
             mass_max=upper_mass_limit,
         )
 
+    mass = mass.flatten() 
     return mass
 
 


### PR DESCRIPTION
Hi Steven,

I found out that the 'while' loop new_masses() loops indefinitely if all the previous stars are considered as stars (i.e. if no stars are filtered out in lines 72-80). This scenario unfortunately happens frequently when `stellar_mass` ~ 10 MSun, and almost definitely happen when `stellar_mass` is small. I think this is due to two reasons:

1. The break condition in line 84 is wrong. Let previous_number_of_stars = A. For the first 0th, 1st, and 2nd iteration:

| N-th interation | `previous_number_of_stars` | `len(additional_mass)` | `len(mass)`| condition|
| --------------- | ---------------------------- | ----------------------- | ----------- | --------- | 
| 0  | A | 0 | A | A + 0 > A (False) |
| 1  | A  | n0 |  A+n0 | A + n0 > A + n0 (False) |
| 2 | A | n1 | A + n0 + n1 | A + n1 > A + n0 + n1 (False)|

and so on. The condition will never be true for any `len(additional_mass)` (edit: correct logic). Please correct me if I misunderstood, but I think you probably want `len(mass) > number_of_stars`, where `number_of_stars` is the parameter. 

2. In almost all scenarios,`len(additional_mass)` becomes 0 within 2 iterations. A failsafe is needed to break the loop. I set the max count to 10, but this can be added as a parameter (though I doubt it needs changing).

Thanks!